### PR TITLE
Point CSS at SVGs in this repo, not reg-status(es)

### DIFF
--- a/style/ochre.css
+++ b/style/ochre.css
@@ -2,7 +2,7 @@ body {
     font-family: Roboto,sans-serif;
     font-weight: 300;
     color: rgb(133, 25, 2);
-    background: url("https://raw.githubusercontent.com/AGLDWG/reg-status/master/style/comms_bg_grey.svg") top right no-repeat;
+    background: url("https://raw.githubusercontent.com/AGLDWG/reg-roles/master/style/comms_bg_grey.svg") top right no-repeat;
     text-align: center;
     margin: 0;
 }
@@ -198,7 +198,7 @@ header {
 }
 
 footer {
-    background: url("https://raw.githubusercontent.com/AGLDWG/reg-status/master/style/comms_footer_bg.svg") top left no-repeat;
+    background: url("https://raw.githubusercontent.com/AGLDWG/reg-roles/master/style/comms_footer_bg.svg") top left no-repeat;
     background-color: #e4e4e4;
     padding: 2em 0 2em 0;
     margin-top: 20px;


### PR DESCRIPTION
The CSS points to two SVGs in the reg-status(es) repo, not this
one. Have the CSS refer to this repo instead.